### PR TITLE
fix to serialize interfaces\abstract types

### DIFF
--- a/NetJSON/NetJSON.cs
+++ b/NetJSON/NetJSON.cs
@@ -3946,9 +3946,13 @@ OpCodes.Call,
             var addMethod = _genericCollectionType.MakeGenericType(elementType).GetMethod("Add");
 
             var prevLabel = il.DefineLabel();
-            
+            var ctor = obj.LocalType.GetConstructor(Type.EmptyTypes);
 
-            il.Emit(OpCodes.Newobj, obj.LocalType.GetConstructor(Type.EmptyTypes));
+            if (ctor != null)
+            {
+                il.Emit(OpCodes.Newobj, ctor);
+            }
+
             il.Emit(OpCodes.Stloc, obj);
 
             il.Emit(OpCodes.Ldc_I4_0);


### PR DESCRIPTION
Try to get Newobj only for types with constructor. Without condition an exception is thrown.